### PR TITLE
refactor: Cart creation from CustomerService

### DIFF
--- a/src/main/java/com/vann/DataLoader.java
+++ b/src/main/java/com/vann/DataLoader.java
@@ -38,7 +38,7 @@ public class DataLoader implements ApplicationRunner {
             ProductService productService = new ProductService(this.productRepo, categoryService);
             LogHandler.serviceClassInitOK(productService.getClass().getName());
             
-            CustomerService customerService = new CustomerService(this.customerRepo);
+            CustomerService customerService = new CustomerService(this.customerRepo, this.cartRepo);
             LogHandler.serviceClassInitOK(customerService.getClass().getName());
             
             InvoiceItemService invoiceItemService = new InvoiceItemService(this.invoiceItemRepo, productService);

--- a/src/main/java/com/vann/controllers/CartController.java
+++ b/src/main/java/com/vann/controllers/CartController.java
@@ -35,7 +35,7 @@ public class CartController {
     @CrossOrigin(origins = "http://localhost:3000")
     @GetMapping("/customer-id/{id}")
     public ResponseEntity<Cart> getCartByCustomerId(@PathVariable UUID id) {
-        Cart cart = cartService.createOrFindCartByCustomerId(id);
+        Cart cart = cartService.findCartByCustomerId(id);
         return ResponseEntity.ok(cart);
     }
 

--- a/src/main/java/com/vann/services/CartService.java
+++ b/src/main/java/com/vann/services/CartService.java
@@ -27,33 +27,21 @@ public class CartService {
     }
 
     @Transactional
-    public Cart createOrFindCartByCustomerId(UUID customerId) throws RecordNotFoundException {
-        Customer customer = customerService.findCustomerById(customerId);
-        try {
-            Cart cart = findCartByCustomerId(customerId);
-            LogHandler.status200OK(CartService.class + " | record found | id=" + cart.getId());
-            return cart;
-        } catch (RecordNotFoundException e) {
-            Cart newCart = saveCart(new Cart(customer, new HashMap<>()));
-            LogHandler.status201Created(CartService.class + " | 1 record created | id=" + newCart.getId());
-            return newCart;
-        }
+    public Cart findCartByCustomerId(UUID id) {
+        customerService.findCustomerById(id);
+        return findCartByExistingCustomerId(id);
     }
 
-    private Cart findCartByCustomerId(UUID customerId) throws RecordNotFoundException {
-        Optional<Cart> cartOptional = cartRepo.findByCustomer_Id(customerId);
+    private Cart findCartByExistingCustomerId(UUID id) throws RecordNotFoundException {
+        Optional<Cart> cartOptional = cartRepo.findByCustomer_Id(id);
         
         if (cartOptional.isPresent()) {
-            LogHandler.status200OK(CartService.class + " | record found | customerId=" + customerId);
-            return cartOptional.get();
+            Cart cart = cartOptional.get();
+            LogHandler.status200OK(CartService.class + " | record found | id=" + cart.getId());
+            return cart;
         } else {
-            throw new RecordNotFoundException(CartService.class + " | record not found | id=" + customerId);
+            throw new RecordNotFoundException(CartService.class + " | record not found | customerId=" + id);
         }
-    }
-
-    @Transactional
-    private Cart saveCart(Cart cart) {
-        return cartRepo.save(cart);
     }
 
     public List<Cart> findAllCarts() {
@@ -139,6 +127,11 @@ public class CartService {
     @Transactional
     private void addNewCartItem(Cart cart, UUID productId, int quantity) {
         cart.getCartItems().put(productId, quantity);
+    }
+
+    @Transactional
+    private Cart saveCart(Cart cart) {
+        return cartRepo.save(cart);
     }
 
     @Transactional

--- a/src/main/java/com/vann/services/InvoiceService.java
+++ b/src/main/java/com/vann/services/InvoiceService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import java.util.*;
 import java.util.Map.Entry;
 
+
 @Service
 public class InvoiceService {
 

--- a/src/main/java/com/vann/services/ProductService.java
+++ b/src/main/java/com/vann/services/ProductService.java
@@ -11,6 +11,7 @@ import com.vann.models.enums.*;
 import com.vann.repositories.ProductRepo;
 import com.vann.utils.LogHandler;
 
+
 @Service
 public class ProductService {
 

--- a/src/test/java/com/vann/services/CartServiceTest.java
+++ b/src/test/java/com/vann/services/CartServiceTest.java
@@ -77,29 +77,27 @@ public class CartServiceTest {
     }
 
     @Test
-    void testCreateOrFindCartByCustomerId_CartExists() {
+    void testFindCartByCustomerId_CartExists() {
         when(cartRepo.findByCustomer_Id(customerId)).thenReturn(Optional.of(cart));
-        Cart result = cartService.createOrFindCartByCustomerId(customerId);
+        Cart result = cartService.findCartByCustomerId(customerId);
         assertEquals(cart, result);
         verify(cartRepo, never()).save(any(Cart.class));
     }
 
     @Test
-    void testCreateOrFindCartByCustomerId_CartDoesNotExist() {
+    void testFindCartByCustomerId_CartDoesNotExist() {
         Customer newCustomer = new Customer("New Customer", "new@customer.com");
         UUID newCustomerId = newCustomer.getId();
     
         when(customerService.findCustomerById(newCustomerId)).thenReturn(newCustomer);
         when(cartRepo.findByCustomer_Id(newCustomerId)).thenReturn(Optional.empty());
-        when(cartRepo.save(any(Cart.class))).thenAnswer(invocation -> invocation.getArgument(0));
-        Cart result = cartService.createOrFindCartByCustomerId(newCustomerId);
+        
+        assertThrows(RecordNotFoundException.class, ()-> {
+            cartService.findCartByCustomerId(newCustomerId);
+        });
     
-        assertNotNull(result, "Cart should not be null");
-        assertEquals(newCustomer, result.getCustomer(), "Cart should have the correct customer");
-        assertTrue(result.getCartItems().isEmpty(), "New cart should be empty");
         verify(customerService).findCustomerById(newCustomerId);
         verify(cartRepo).findByCustomer_Id(newCustomerId);
-        verify(cartRepo).save(result);
     }
 
     @Test

--- a/src/test/java/com/vann/services/CustomerServiceTest.java
+++ b/src/test/java/com/vann/services/CustomerServiceTest.java
@@ -1,6 +1,7 @@
 package com.vann.services;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.*;
@@ -9,8 +10,8 @@ import org.junit.jupiter.api.*;
 import org.mockito.*;
 
 import com.vann.exceptions.*;
-import com.vann.models.Customer;
-import com.vann.repositories.CustomerRepo;
+import com.vann.models.*;
+import com.vann.repositories.*;
 
 
 class CustomerServiceTest {
@@ -18,12 +19,28 @@ class CustomerServiceTest {
     @Mock
     private CustomerRepo customerRepo;
 
+    @Mock
+    private CartRepo cartRepo;
+
     @InjectMocks
     private CustomerService customerService;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testCreateOne() {
+        Customer mockCustomer = new Customer("John Doe", "john.doe@example.com");
+        when(customerRepo.save(any(Customer.class))).thenReturn(mockCustomer);
+        when(cartRepo.save(any(Cart.class))).thenReturn(new Cart());
+    
+        Customer savedCustomer = customerService.createOne(mockCustomer);
+    
+        assertEquals(mockCustomer, savedCustomer);
+        verify(customerRepo, times(1)).save(mockCustomer);
+        verify(cartRepo, times(1)).save(any(Cart.class));
     }
 
     @Test


### PR DESCRIPTION
Moves cart creation to the CustomerService createOne() method.

This decision was taken as a workaround to prevent issues of needing to instantiate the CartService and CustomerService classes with instances of each other as attributes.

The CustomerService is granted a single permission to interact directly with the CartRepo for the purpose of creating a new Cart when a Customer is created.