### PR TITLE
fix: Cart quantities during updates

### DIFF
--- a/src/main/java/com/vann/services/CartService.java
+++ b/src/main/java/com/vann/services/CartService.java
@@ -76,10 +76,8 @@ public class CartService {
     
         for (Map.Entry<UUID, Integer> entry : items.entrySet()) {
             UUID productId = entry.getKey();
-            int quantity = entry.getValue();
             try {
                 validateProductId(productId);
-                addOrUpdateCartItem(cart, productId, quantity);
             } catch (RecordNotFoundException e) {
                 errorMessages.add(e.getMessage());
             } catch (Exception e) {
@@ -88,6 +86,7 @@ public class CartService {
         }
 
         if (errorMessages.isEmpty()) {
+            cart.setCartItems(items);
             Cart savedCart = saveCart(cart);
             LogHandler.status200OK(CartService.class + " | " + items.size() + " entries updated");
             return savedCart;
@@ -98,35 +97,6 @@ public class CartService {
 
     private void validateProductId(UUID productId) throws RecordNotFoundException {
         productService.findProductById(productId);
-    }
-
-    @Transactional
-    private void addOrUpdateCartItem(Cart cart, UUID productId, int quantity) {
-        int existingQuantity = findExistingCartItem(cart, productId);
-        if (existingQuantity >= 0) {
-            updateExistingCartItem(cart, productId, quantity);
-        } else {
-            addNewCartItem(cart, productId, quantity);
-        }
-    }
-
-    private int findExistingCartItem(Cart cart, UUID productId) {
-        return cart.getCartItems().getOrDefault(productId, 0);
-    }
-
-    @Transactional
-    private void updateExistingCartItem(Cart cart, UUID productId, int quantity) {
-        int updatedQuantity = cart.getCartItems().getOrDefault(productId, 0) + quantity;
-        if (updatedQuantity <= 0) {
-            cart.getCartItems().remove(productId);
-        } else {
-            cart.getCartItems().put(productId, updatedQuantity);
-        }
-    }
-
-    @Transactional
-    private void addNewCartItem(Cart cart, UUID productId, int quantity) {
-        cart.getCartItems().put(productId, quantity);
     }
 
     @Transactional

--- a/src/test/java/com/vann/services/CartServiceTest.java
+++ b/src/test/java/com/vann/services/CartServiceTest.java
@@ -133,7 +133,7 @@ public class CartServiceTest {
         Cart result = cartService.addOrUpdateCartItems(cartId, items);
 
         assertEquals(1, result.getCartItems().size());
-        assertEquals(3, result.getCartItems().get(productId1));
+        assertEquals(2, result.getCartItems().get(productId1));
         verify(cartRepo).save(result);
     }
 
@@ -156,8 +156,7 @@ public class CartServiceTest {
     
         Cart result = cartService.findCartById(cartId);
         assertNotNull(result, "Cart should not be null");
-        assertEquals(1, result.getCartItems().size(), "Cart should contain only valid items");
-        assertEquals(2, result.getCartItems().get(productId1), "Cart should have the correct quantity for the valid product");
+        assertEquals(0, result.getCartItems().size(), "Cart should be empty (updates with invalid items will be rolled back)");
     
         verify(cartRepo, times(2)).findById(cartId);
         verify(productService).findProductById(productId1);


### PR DESCRIPTION
Fixes an issue whereby each time items were added to a user's cart, the quantities of items already in the cart would double.

The approach to update cart contents has changed from an item-level basis, to a full overwrite via the `cart.setCartItems()` method.

This simpler approach enables the removal of several private methods no longer needed.

Backend unit tests are all passing, and frontend integration tests passed also.